### PR TITLE
CKAN 2.9.x upgrade

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ language: python
 services:
   - docker
 
+# we need coveralls and this also prevents travis from running pip install -r requirements.txt
+install: pip install coveralls
+
 script:
-  - pip install coveralls
   - docker-compose build
   - docker-compose run ckan
 
 after_success: coveralls
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+script:
+  - pip install coveralls
+  - docker-compose build
+  - docker-compose run ckan
+
+after_success: coveralls

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include README.rst
-include LICENSE
-include requirements.txt
-recursive-include ckanext/iiif *.html *.json *.js *.less *.css *.mo

--- a/ckanext/iiif/__init__.py
+++ b/ckanext/iiif/__init__.py
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+# this is a namespace package
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -36,8 +36,10 @@ class IIIFRecordManifestBuilder(object):
     @property
     def images(self):
         value = self.record[self.resource[u'_image_field']]
-        delimeter = self.resource[u'_image_delimiter']
-        return value.split(delimeter) if delimeter else [value]
+        if u'_image_delimiter' in self.resource:
+            return value.split(self.resource[u'_image_delimiter'])
+        else:
+            return value if isinstance(value, list) else [value]
 
     @property
     def rights(self):
@@ -51,6 +53,7 @@ class IIIFRecordManifestBuilder(object):
 
     @property
     def metadata(self):
+        # TODO: this function does not handle lists of values well, nor nested dicts...
         return [
             {u'label': wrap_language(field), u'value': wrap_language(unicode(value))}
             for field, value in self.record.items()

--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -36,8 +36,9 @@ class IIIFRecordManifestBuilder(object):
     @property
     def images(self):
         value = self.record[self.resource['_image_field']]
-        if '_image_delimiter' in self.resource:
-            return value.split(self.resource['_image_delimiter'])
+        image_delimiter = self.resource.get('_image_delimiter', None)
+        if image_delimiter:
+            return value.split(image_delimiter)
         else:
             return value if isinstance(value, list) else [value]
 

--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -8,46 +8,46 @@ from .utils import create_id_url, create_image_server_url, wrap_language
 
 class IIIFRecordManifestBuilder(object):
     # the group names here must match the parameters for the get_builder function below
-    regex = re.compile(u'resource/(?P<resource_id>.+?)/record/(?P<record_id>.+)$')
+    regex = re.compile('resource/(?P<resource_id>.+?)/record/(?P<record_id>.+)$')
 
     @staticmethod
     def get_builder(resource_id, record_id):
         # this will throw an error if the resource can't be found
-        resource = toolkit.get_action(u'resource_show')({}, {u'id': resource_id})
+        resource = toolkit.get_action('resource_show')({}, {'id': resource_id})
         # this will throw an error if the record can't be found
-        record = toolkit.get_action(u'record_show')({}, {u'resource_id': resource_id,
-                                                         u'record_id': record_id})
-        return IIIFRecordManifestBuilder(resource, record[u'data'])
+        record = toolkit.get_action('record_show')({}, {'resource_id': resource_id,
+                                                        'record_id': record_id})
+        return IIIFRecordManifestBuilder(resource, record['data'])
 
     def __init__(self, resource, record):
         self.resource = resource
         self.record = record
-        self.resource_id = resource[u'id']
-        self.record_id = record[u'_id']
+        self.resource_id = resource['id']
+        self.record_id = record['_id']
 
     @property
     def manifest_id(self):
-        return u'resource/{}/record/{}'.format(self.resource_id, self.record_id)
+        return f'resource/{self.resource_id}/record/{self.record_id}'
 
     @property
     def label(self):
-        return wrap_language(self.record[self.resource[u'_title_field']])
+        return wrap_language(self.record[self.resource['_title_field']])
 
     @property
     def images(self):
-        value = self.record[self.resource[u'_image_field']]
-        if u'_image_delimiter' in self.resource:
-            return value.split(self.resource[u'_image_delimiter'])
+        value = self.record[self.resource['_image_field']]
+        if '_image_delimiter' in self.resource:
+            return value.split(self.resource['_image_delimiter'])
         else:
             return value if isinstance(value, list) else [value]
 
     @property
     def rights(self):
-        license_id = self.resource.get(u'_image_licence', None)
+        license_id = self.resource.get('_image_licence', None)
         # if the license is '' or None we override it
         if not license_id:
             # default the license to cc-by
-            license_id = u'cc-by'
+            license_id = 'cc-by'
         license = model.Package.get_license_register()[license_id]
         return license.url
 
@@ -55,46 +55,46 @@ class IIIFRecordManifestBuilder(object):
     def metadata(self):
         # TODO: this function does not handle lists of values well, nor nested dicts...
         return [
-            {u'label': wrap_language(field), u'value': wrap_language(unicode(value))}
+            {'label': wrap_language(field), 'value': wrap_language(str(value))}
             for field, value in self.record.items()
         ]
 
     def build_canvas(self, image):
-        canvas_id = create_id_url(u'{}/canvas/{}'.format(self.manifest_id, image))
+        canvas_id = create_id_url(f'{self.manifest_id}/canvas/{image}')
         # TODO: need to pass the type based on some logic (user setting/custom code)
         image_id = create_image_server_url(image)
 
         return {
-            u'id': canvas_id,
-            u'type': u'Canvas',
+            'id': canvas_id,
+            'type': 'Canvas',
             # we don't have access to the image data or metadata here so just use 1000x1000
-            u'width': 1000,
-            u'height': 1000,
+            'width': 1000,
+            'height': 1000,
             # TODO: label needs to be using a field defined by the user
-            u'label': wrap_language(image),
-            u'items': [
+            'label': wrap_language(image),
+            'items': [
                 {
                     # TODO: do we need an id here?
-                    u'type': u'AnnotationPage',
-                    u'items': [
+                    'type': 'AnnotationPage',
+                    'items': [
                         {
                             # TODO: do we need an id here?
-                            u'type': u'Annotation',
-                            u'motivation': u'painting',
-                            u'body': {
-                                u'id': u'{}/{}'.format(image_id, u'info.json'),
-                                u'type': u'Image',
-                                u'format': u'image/jpeg',
-                                u'service': [
+                            'type': 'Annotation',
+                            'motivation': 'painting',
+                            'body': {
+                                'id': f'{image_id}/info.json',
+                                'type': 'Image',
+                                'format': 'image/jpeg',
+                                'service': [
                                     {
-                                        u'@context': u'http://iiif.io/api/image/3/context.json',
-                                        u'id': image_id,
-                                        u'type': u'ImageService3',
-                                        u'profile': u'level0'
+                                        '@context': 'http://iiif.io/api/image/3/context.json',
+                                        'id': image_id,
+                                        'type': 'ImageService3',
+                                        'profile': 'level0'
                                     }
                                 ],
                             },
-                            u'target': canvas_id,
+                            'target': canvas_id,
                         },
                     ]
                 }
@@ -104,20 +104,20 @@ class IIIFRecordManifestBuilder(object):
     def build(self):
         # TODO: add more properties
         return {
-            u'@context': u'http://iiif.io/api/presentation/3/context.json',
-            u'id': create_id_url(self.manifest_id),
-            u'type': u'Manifest',
-            u'label': self.label,
-            u'metadata': self.metadata,
-            u'rights': self.rights,
-            u'items': [self.build_canvas(image) for image in self.images],
-            u'logo': [
+            '@context': 'http://iiif.io/api/presentation/3/context.json',
+            'id': create_id_url(self.manifest_id),
+            'type': 'Manifest',
+            'label': self.label,
+            'metadata': self.metadata,
+            'rights': self.rights,
+            'items': [self.build_canvas(image) for image in self.images],
+            'logo': [
                 {
-                    u'id': u'{}/images/logo.png'.format(config.get(u'ckan.site_url')),
-                    u'type': u'Image',
-                    u'format': u'image/png',
-                    u'width': 120,
-                    u'height': 56,
+                    'id': f'{config.get("ckan.site_url")}/images/logo.png',
+                    'type': 'Image',
+                    'format': 'image/png',
+                    'width': 120,
+                    'height': 56,
                 }
             ],
         }

--- a/ckanext/iiif/lib/utils.py
+++ b/ckanext/iiif/lib/utils.py
@@ -3,15 +3,15 @@ from ckan.plugins import toolkit
 
 
 def create_id_url(identifier):
-    return toolkit.url_for(u'iiif.resource', identifier=identifier, _external=True)
+    return toolkit.url_for('iiif.resource', identifier=identifier, _external=True)
 
 
-def create_image_server_url(identifier_name, identifier_type=u'vfactor'):
-    image_server_url = config.get(u'ckanext.iiif.image_server_url')
-    return u'{}/{}:{}'.format(image_server_url, identifier_type, identifier_name)
+def create_image_server_url(identifier_name, identifier_type='vfactor'):
+    image_server_url = config.get('ckanext.iiif.image_server_url')
+    return f'{image_server_url}/{identifier_type}:{identifier_name}'
 
 
-def wrap_language(value, language=u'en'):
+def wrap_language(value, language='en'):
     if not isinstance(value, list):
         value = [value]
     return {language: value}

--- a/ckanext/iiif/plugin.py
+++ b/ckanext/iiif/plugin.py
@@ -1,7 +1,7 @@
 import ckan.plugins as plugins
 import logging
 from ckan.plugins import toolkit
-from contextlib2 import suppress
+from contextlib import suppress
 
 from . import interfaces
 from . import routes

--- a/ckanext/iiif/plugin.py
+++ b/ckanext/iiif/plugin.py
@@ -53,8 +53,7 @@ class IIIFPlugin(plugins.SingletonPlugin):
                 if resource_id not in resource_cache:
                     resource_cache[resource_id] = resource_show({}, {'id': resource_id})
                 with suppress(Exception):
-                    builder = IIIFRecordManifestBuilder(resource_cache[resource_id],
-                                                        record['data'])
+                    builder = IIIFRecordManifestBuilder(resource_cache[resource_id], record['data'])
                     record['iiif'] = builder.build()
 
         return response

--- a/ckanext/iiif/plugin.py
+++ b/ckanext/iiif/plugin.py
@@ -1,6 +1,5 @@
-import logging
-
 import ckan.plugins as plugins
+import logging
 from ckan.plugins import toolkit
 from contextlib2 import suppress
 
@@ -35,7 +34,7 @@ class IIIFPlugin(plugins.SingletonPlugin):
         for plugin in plugins.PluginImplementations(interfaces.IIIIF):
             for builder in plugin.get_builders():
                 if builder.regex in iiif.builders:
-                    log.warning(u'Duplicate IIIF builder regex: {}'.format(builder.regex.pattern))
+                    log.warning('Duplicate IIIF builder regex: {}'.format(builder.regex.pattern))
                 iiif.builders[builder.regex] = builder.get_builder
 
     # IBlueprint
@@ -45,17 +44,17 @@ class IIIFPlugin(plugins.SingletonPlugin):
     # IVersionedDatastore
     def datastore_multisearch_modify_response(self, response):
         resource_cache = {}
-        resource_show = toolkit.get_action(u'resource_show')
-        vfactor_resource_id = toolkit.config.get(u'ckanext.nhm.vfactor_resource_id')
+        resource_show = toolkit.get_action('resource_show')
+        vfactor_resource_id = toolkit.config.get('ckanext.nhm.vfactor_resource_id')
 
-        for record in response[u'records']:
-            resource_id = record[u'resource']
+        for record in response['records']:
+            resource_id = record['resource']
             if resource_id == vfactor_resource_id:
                 if resource_id not in resource_cache:
-                    resource_cache[resource_id] = resource_show({}, {u'id': resource_id})
+                    resource_cache[resource_id] = resource_show({}, {'id': resource_id})
                 with suppress(Exception):
                     builder = IIIFRecordManifestBuilder(resource_cache[resource_id],
-                                                        record[u'data'])
-                    record[u'iiif'] = builder.build()
+                                                        record['data'])
+                    record['iiif'] = builder.build()
 
         return response

--- a/ckanext/iiif/routes/iiif.py
+++ b/ckanext/iiif/routes/iiif.py
@@ -1,14 +1,13 @@
-from collections import OrderedDict
-
 from ckan.plugins import toolkit
+from collections import OrderedDict
 from flask import Blueprint, jsonify
 
-blueprint = Blueprint(name=u'iiif', import_name=__name__, url_prefix=u'/iiif')
+blueprint = Blueprint(name='iiif', import_name=__name__, url_prefix='/iiif')
 
 builders = OrderedDict()
 
 
-@blueprint.route(u'/<path:identifier>')
+@blueprint.route('/<path:identifier>')
 def resource(identifier):
     for regex, get_builder_function in builders.items():
         match = regex.match(identifier)
@@ -16,4 +15,4 @@ def resource(identifier):
             builder = get_builder_function(**match.groupdict())
             return jsonify(builder.build())
 
-    return toolkit.abort(status_code=404, detail=u'Unknown IIIF identifier')
+    return toolkit.abort(status_code=404, detail='Unknown IIIF identifier')

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,2 @@
-mock
 pytest>=4.6.5
 pytest-cov>=2.7.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,3 @@
+mock
+pytest>=4.6.5
+pytest-cov>=2.7.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3"
+
+services:
+  ckan:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    environment:
+      PYTHONUNBUFFERED: 1
+      PYTHONDONTWRITEBYTECODE: 1
+    depends_on:
+      - db
+      - solr
+      - redis
+    volumes:
+      - .:/srv/app/src/ckanext-iiif
+
+  solr:
+    build:
+      context: https://github.com/okfn/docker-ckan.git#:solr
+    logging:
+      driver: none
+
+  db:
+    build:
+      context: https://github.com/okfn/docker-ckan.git#:postgresql
+      args:
+        - DATASTORE_READONLY_PASSWORD=password
+        - POSTGRES_PASSWORD=password
+    environment:
+      - DATASTORE_READONLY_PASSWORD=password
+      - POSTGRES_PASSWORD=password
+    logging:
+      driver: none
+
+  redis:
+    image: redis:latest
+    logging:
+      driver: none

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openknowledge/ckan-dev:2.9-py2
+FROM openknowledge/ckan-dev:2.9
 
 # ckan is installed in /srv/app/src/ckan in the ckan-dev image we're basing this image on
 WORKDIR /srv/app/src/ckanext-iiif
@@ -7,15 +7,15 @@ WORKDIR /srv/app/src/ckanext-iiif
 COPY . .
 
 # might as well update pip while we're here!
-RUN pip2 install --upgrade pip
+RUN pip3 install --upgrade pip
 
 # fixes this https://github.com/ckan/ckan/issues/5570
-RUN pip2 install pytest-ckan
+RUN pip3 install pytest-ckan
 
 # install the dependencies
-RUN python2 setup.py develop && \
-    pip2 install -r requirements.txt && \
-    pip2 install -r dev_requirements.txt
+RUN python3 setup.py develop && \
+    pip3 install -r requirements.txt && \
+    pip3 install -r dev_requirements.txt
 
 # this entrypoint ensures our service dependencies (postgresql, solr and redis) are running before
 # running the cmd

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM openknowledge/ckan-dev:2.9-py2
+
+# ckan is installed in /srv/app/src/ckan in the ckan-dev image we're basing this image on
+WORKDIR /srv/app/src/ckanext-iiif
+
+# copy over the ckanext-iiif source
+COPY . .
+
+# might as well update pip while we're here!
+RUN pip2 install --upgrade pip
+
+# fixes this https://github.com/ckan/ckan/issues/5570
+RUN pip2 install pytest-ckan
+
+# install the dependencies
+RUN python2 setup.py develop && \
+    pip2 install -r requirements.txt && \
+    pip2 install -r dev_requirements.txt
+
+# this entrypoint ensures our service dependencies (postgresql, solr and redis) are running before
+# running the cmd
+ENTRYPOINT ["/bin/bash", "docker/entrypoint.sh"]
+
+# run the tests with coverage output
+CMD ["pytest", "--cov=ckanext.iiif", "--ckan-ini=test.ini", "tests"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "Wait for PostgreSQL to start..."
+while ! pg_isready -h db -U ckan; do
+    sleep 1;
+done
+echo "PostgreSQL started"
+
+echo "Wait for Solr to start..."
+while ! curl -s "http://solr:8983/solr/ckan/admin/ping" | grep -q OK; do
+  sleep 1;
+done
+echo "Solr started"
+
+echo "Wait for Redis to start..."
+while ! echo -e "PING" | nc -w 1 redis 6379 | grep -q "+PONG"; do
+  sleep 1;
+done
+echo "Redis started"
+
+echo "All services up, running command"
+
+exec "$@"

--- a/setup.py
+++ b/setup.py
@@ -3,49 +3,36 @@ from setuptools import setup, find_packages  # Always prefer setuptools over dis
 from codecs import open  # To use a consistent encoding
 from os import path
 
-__version__ = u'1.0.0-alpha'
+__version__ = '2.0.0'
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, u'README.md'), encoding=u'utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     __long_description__ = f.read()
 
 setup(
-    name=u'ckanext-iiif',
+    name='ckanext-iiif',
     version=__version__,
-    description=u'A IIIF extenstion for CKAN',
+    description='A IIIF extenstion for CKAN',
     long_description=__long_description__,
-    url=u'https://github.com/NaturalHistoryMuseum/ckanext-iiif',
-    author=u'Natural History Museum',
-    author_email=u'data@nhm.ac.uk',
-    license=u'GNU GPLv3',
+    url='https://github.com/NaturalHistoryMuseum/ckanext-iiif',
+    author='Natural History Museum',
+    author_email='data@nhm.ac.uk',
+    license='GNU GPLv3',
     classifiers=[
-        u'Development Status :: 3 - Alpha',
-        u'License :: OSI Approved :: GNU General Public License v3 (GNU GPLv3)',
-        u'Programming Language :: Python :: 2.7',
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: GNU General Public License v3 (GNU GPLv3)',
+        'Programming Language :: Python :: 2.7',
     ],
-    keywords=u'CKAN IIIF',
-    packages=find_packages(exclude=[u'contrib', u'docs', u'tests*']),
-    namespace_packages=[u'ckanext'],
-    install_requires=[
-        u'six',
-        u'contextlib2>=0.6.0.post1',
-    ],
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
+    keywords='CKAN IIIF',
+    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    namespace_packages=['ckanext', 'ckanext.iiif'],
+    install_requires=[],
     include_package_data=True,
     package_data={
     },
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages.
-    # see http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
     data_files=[],
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    entry_points=u'''
+    entry_points='''
         [ckan.plugins]
         iiif=ckanext.iiif.plugin:IIIFPlugin
     '''

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     namespace_packages=[u'ckanext'],
     install_requires=[
         u'six',
+        u'contextlib2>=0.6.0.post1',
     ],
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=[u'contrib', u'docs', u'tests*']),
     namespace_packages=[u'ckanext'],
     install_requires=[
-        u'six~=1.11.0',
+        u'six',
     ],
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/test.ini
+++ b/test.ini
@@ -1,0 +1,51 @@
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+
+[app:main]
+# use a full path to ensure the config is picked up wherever the tests are run from (this covers off
+# both the default setup, where the tests are run from /srv/app/src/ckanext-iiif/, and running them
+# from an IDE like PyCharm which will copy the code into /opt/project/ and run it from there
+use = config:/srv/app/src/ckan/test-core.ini
+
+# the hosts referenced here resolve to the other docker containers configured in docker-compose.yml
+sqlalchemy.url = postgresql://ckan:password@db/ckan
+ckan.datastore.write_url = postgresql://ckan:password@db/datastore
+ckan.datastore.read_url = postgresql://datastore_ro:password@db/datastore
+ckan.redis.url = redis://redis:6379/1
+solr_url = http://solr:8983/solr/ckan
+
+[loggers]
+keys = root, ckan, ckanext
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+
+[logger_ckan]
+level = INFO
+handlers = console
+qualname = ckan
+propagate = 0
+
+[logger_ckanext]
+level = DEBUG
+handlers = console
+qualname = ckanext
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,59 @@
+from ckan import model
+from mock import MagicMock
+
+from ckanext.iiif.lib.manifest import IIIFRecordManifestBuilder
+
+
+class TestIIIFRecordManifestBuilder(object):
+
+    def test_manifest_id(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1}, {u'_id': 1})
+        assert builder.manifest_id == u'resource/1/record/1'
+
+    def test_label(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1, u'_title_field': u'title'},
+                                            {u'_id': 1, u'title': u'The title!'})
+        assert builder.label == {u'en': [u'The title!']}
+
+    def test_images_multiple_comma_separated(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images',
+                                             u'_image_delimiter': u','},
+                                            {u'_id': 1, u'images': u'image1,image2,image3'})
+        assert builder.images == [u'image1', u'image2', u'image3']
+
+    def test_images_multiple_in_a_list(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images'},
+                                            {u'_id': 1,
+                                             u'images': [u'image1', u'image2', u'image3']})
+        assert builder.images == [u'image1', u'image2', u'image3']
+
+    def test_images_single_comma_separated(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images',
+                                             u'_image_delimiter': u','},
+                                            {u'_id': 1, u'images': u'image1'})
+        assert builder.images == [u'image1']
+
+    def test_images_single(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images'},
+                                            {u'_id': 1, u'images': u'image1'})
+        assert builder.images == [u'image1']
+
+    def test_rights_default(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1}, {u'_id': 1})
+        assert builder.rights == model.Package.get_license_register()[u'cc-by'].url
+
+    def test_rights_when_set(self):
+        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_licence': u'cc-zero'}, {u'_id': 1})
+        assert builder.rights == model.Package.get_license_register()[u'cc-zero'].url
+
+    def test_metadata(self):
+        record_data = {
+            u'field1': u'beans',
+            u'field2': u'goats',
+        }
+        builder = IIIFRecordManifestBuilder({u'id': 1}, dict(_id=1, **record_data))
+        metadata = builder.metadata
+        assert len(metadata) == 3
+        assert {u'label': {u'en': [u'_id']}, u'value': {u'en': [u'1']}} in metadata
+        assert {u'label': {u'en': [u'field1']}, u'value': {u'en': [u'beans']}} in metadata
+        assert {u'label': {u'en': [u'field2']}, u'value': {u'en': [u'goats']}} in metadata

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,5 +1,4 @@
 from ckan import model
-from mock import MagicMock
 
 from ckanext.iiif.lib.manifest import IIIFRecordManifestBuilder
 
@@ -7,53 +6,52 @@ from ckanext.iiif.lib.manifest import IIIFRecordManifestBuilder
 class TestIIIFRecordManifestBuilder(object):
 
     def test_manifest_id(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1}, {u'_id': 1})
-        assert builder.manifest_id == u'resource/1/record/1'
+        builder = IIIFRecordManifestBuilder({'id': 1}, {'_id': 1})
+        assert builder.manifest_id == 'resource/1/record/1'
 
     def test_label(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1, u'_title_field': u'title'},
-                                            {u'_id': 1, u'title': u'The title!'})
-        assert builder.label == {u'en': [u'The title!']}
+        builder = IIIFRecordManifestBuilder({'id': 1, '_title_field': 'title'},
+                                            {'_id': 1, 'title': 'The title!'})
+        assert builder.label == {'en': ['The title!']}
 
     def test_images_multiple_comma_separated(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images',
-                                             u'_image_delimiter': u','},
-                                            {u'_id': 1, u'images': u'image1,image2,image3'})
-        assert builder.images == [u'image1', u'image2', u'image3']
+        builder = IIIFRecordManifestBuilder({'id': 1, '_image_field': 'images',
+                                             '_image_delimiter': ','},
+                                            {'_id': 1, 'images': 'image1,image2,image3'})
+        assert builder.images == ['image1', 'image2', 'image3']
 
     def test_images_multiple_in_a_list(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images'},
-                                            {u'_id': 1,
-                                             u'images': [u'image1', u'image2', u'image3']})
-        assert builder.images == [u'image1', u'image2', u'image3']
+        builder = IIIFRecordManifestBuilder({'id': 1, '_image_field': 'images'},
+                                            {'_id': 1, 'images': ['image1', 'image2', 'image3']})
+        assert builder.images == ['image1', 'image2', 'image3']
 
     def test_images_single_comma_separated(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images',
-                                             u'_image_delimiter': u','},
-                                            {u'_id': 1, u'images': u'image1'})
-        assert builder.images == [u'image1']
+        builder = IIIFRecordManifestBuilder({'id': 1, '_image_field': 'images',
+                                             '_image_delimiter': ','},
+                                            {'_id': 1, 'images': 'image1'})
+        assert builder.images == ['image1']
 
     def test_images_single(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_field': u'images'},
-                                            {u'_id': 1, u'images': u'image1'})
-        assert builder.images == [u'image1']
+        builder = IIIFRecordManifestBuilder({'id': 1, '_image_field': 'images'},
+                                            {'_id': 1, 'images': 'image1'})
+        assert builder.images == ['image1']
 
     def test_rights_default(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1}, {u'_id': 1})
-        assert builder.rights == model.Package.get_license_register()[u'cc-by'].url
+        builder = IIIFRecordManifestBuilder({'id': 1}, {'_id': 1})
+        assert builder.rights == model.Package.get_license_register()['cc-by'].url
 
     def test_rights_when_set(self):
-        builder = IIIFRecordManifestBuilder({u'id': 1, u'_image_licence': u'cc-zero'}, {u'_id': 1})
-        assert builder.rights == model.Package.get_license_register()[u'cc-zero'].url
+        builder = IIIFRecordManifestBuilder({'id': 1, '_image_licence': 'cc-zero'}, {'_id': 1})
+        assert builder.rights == model.Package.get_license_register()['cc-zero'].url
 
     def test_metadata(self):
         record_data = {
-            u'field1': u'beans',
-            u'field2': u'goats',
+            'field1': 'beans',
+            'field2': 'goats',
         }
-        builder = IIIFRecordManifestBuilder({u'id': 1}, dict(_id=1, **record_data))
+        builder = IIIFRecordManifestBuilder({'id': 1}, {u'_id': 1, **record_data})
         metadata = builder.metadata
         assert len(metadata) == 3
-        assert {u'label': {u'en': [u'_id']}, u'value': {u'en': [u'1']}} in metadata
-        assert {u'label': {u'en': [u'field1']}, u'value': {u'en': [u'beans']}} in metadata
-        assert {u'label': {u'en': [u'field2']}, u'value': {u'en': [u'goats']}} in metadata
+        assert {'label': {'en': ['_id']}, 'value': {'en': ['1']}} in metadata
+        assert {'label': {'en': ['field1']}, 'value': {'en': ['beans']}} in metadata
+        assert {'label': {'en': ['field2']}, 'value': {'en': ['goats']}} in metadata

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,37 +1,38 @@
-import re
-
 import pytest
-from ckanext.iiif.routes.iiif import resource
+import re
 from mock import patch, MagicMock, call
+
+from ckanext.iiif.routes.iiif import resource
 
 
 def test_no_builders():
     # TODO: it would be nicer to not mock the toolkit.abort function and just use pytest.raises on
     #       the HTTPException that it raises, but I can't get that to work :(
     mock_builders = {}
-    mock_toolkit = MagicMock(abort=MagicMock(side_effect=Exception(u'yep')))
+    mock_toolkit = MagicMock(abort=MagicMock(side_effect=Exception('yep')))
 
-    with patch(u'ckanext.iiif.routes.iiif.builders', mock_builders):
-        with patch(u'ckanext.iiif.routes.iiif.toolkit', mock_toolkit):
-            with pytest.raises(Exception, match=u'yep'):
+    with patch('ckanext.iiif.routes.iiif.builders', mock_builders):
+        with patch('ckanext.iiif.routes.iiif.toolkit', mock_toolkit):
+            with pytest.raises(Exception, match='yep'):
                 resource(MagicMock())
 
-    assert mock_toolkit.abort.call_args == call(status_code=404, detail=u'Unknown IIIF identifier')
+    assert mock_toolkit.abort.call_args == call(status_code=404, detail='Unknown IIIF identifier')
 
 
-@pytest.mark.usefixtures(u'with_request_context')
+@pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')
+@pytest.mark.usefixtures('with_request_context')
 def test_match():
-    identifier = u'resource/1/record/1'
+    identifier = 'resource/1/record/1'
 
     mock_get_builder = MagicMock(return_value=MagicMock(build=MagicMock(return_value={})))
     mock_builders = {
-        re.compile(u'resource/(?P<resource_id>.+?)/record/(?P<record_id>.+)$'): mock_get_builder
+        re.compile('resource/(?P<resource_id>.+?)/record/(?P<record_id>.+)$'): mock_get_builder
     }
 
-    with patch(u'ckanext.iiif.routes.iiif.builders', mock_builders):
+    with patch('ckanext.iiif.routes.iiif.builders', mock_builders):
         response = resource(identifier)
 
     assert response.status_code == 200
-    assert response.mimetype == u'application/json'
-    assert response.data.strip() == u'{}'
-    assert mock_get_builder.call_args == call(resource_id=u'1', record_id=u'1')
+    assert response.mimetype == 'application/json'
+    assert response.data.strip() == b'{}'
+    assert mock_get_builder.call_args == call(resource_id='1', record_id='1')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,37 @@
+import re
+
+import pytest
+from ckanext.iiif.routes.iiif import resource
+from mock import patch, MagicMock, call
+
+
+def test_no_builders():
+    # TODO: it would be nicer to not mock the toolkit.abort function and just use pytest.raises on
+    #       the HTTPException that it raises, but I can't get that to work :(
+    mock_builders = {}
+    mock_toolkit = MagicMock(abort=MagicMock(side_effect=Exception(u'yep')))
+
+    with patch(u'ckanext.iiif.routes.iiif.builders', mock_builders):
+        with patch(u'ckanext.iiif.routes.iiif.toolkit', mock_toolkit):
+            with pytest.raises(Exception, match=u'yep'):
+                resource(MagicMock())
+
+    assert mock_toolkit.abort.call_args == call(status_code=404, detail=u'Unknown IIIF identifier')
+
+
+@pytest.mark.usefixtures(u'with_request_context')
+def test_match():
+    identifier = u'resource/1/record/1'
+
+    mock_get_builder = MagicMock(return_value=MagicMock(build=MagicMock(return_value={})))
+    mock_builders = {
+        re.compile(u'resource/(?P<resource_id>.+?)/record/(?P<record_id>.+)$'): mock_get_builder
+    }
+
+    with patch(u'ckanext.iiif.routes.iiif.builders', mock_builders):
+        response = resource(identifier)
+
+    assert response.status_code == 200
+    assert response.mimetype == u'application/json'
+    assert response.data.strip() == u'{}'
+    assert mock_get_builder.call_args == call(resource_id=u'1', record_id=u'1')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,18 @@
 import pytest
-from ckanext.iiif.lib.utils import wrap_language, create_image_server_url
 from mock import MagicMock
 
+from ckanext.iiif.lib.utils import wrap_language, create_image_server_url
 
-@pytest.mark.ckan_config(u'ckanext.iiif.image_server_url', u'https://something.com')
+
+@pytest.mark.ckan_config('ckanext.iiif.image_server_url', 'https://something.com')
 def test_create_image_server_url():
-    result = create_image_server_url(u'an_identifier!', identifier_type=u'a_type!')
-    assert result == u'https://something.com/a_type!:an_identifier!'
+    result = create_image_server_url('an_identifier!', identifier_type='a_type!')
+    assert result == 'https://something.com/a_type!:an_identifier!'
 
 
 def test_wrap_language():
     test_value = MagicMock()
 
-    assert wrap_language(test_value) == {u'en': [test_value]}
-    assert wrap_language([test_value]) == {u'en': [test_value]}
-    assert wrap_language(test_value, language=u'beans') == {u'beans': [test_value]}
+    assert wrap_language(test_value) == {'en': [test_value]}
+    assert wrap_language([test_value]) == {'en': [test_value]}
+    assert wrap_language(test_value, language='beans') == {'beans': [test_value]}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+from ckanext.iiif.lib.utils import wrap_language, create_image_server_url
+from mock import MagicMock
+
+
+@pytest.mark.ckan_config(u'ckanext.iiif.image_server_url', u'https://something.com')
+def test_create_image_server_url():
+    result = create_image_server_url(u'an_identifier!', identifier_type=u'a_type!')
+    assert result == u'https://something.com/a_type!:an_identifier!'
+
+
+def test_wrap_language():
+    test_value = MagicMock()
+
+    assert wrap_language(test_value) == {u'en': [test_value]}
+    assert wrap_language([test_value]) == {u'en': [test_value]}
+    assert wrap_language(test_value, language=u'beans') == {u'beans': [test_value]}


### PR DESCRIPTION
Upgrades this extension to work with Python 3 and CKAN 2.9.x.

**Note: this PR removes Python 2 support and therefore this extension will only support CKAN >=2.9.x on Python 3.**