### PR TITLE
Update manifest generation to be more compliant and more usable

### DIFF
--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -98,7 +98,7 @@ class IIIFRecordManifestBuilder:
                             'type': 'Annotation',
                             'motivation': 'painting',
                             'body': {
-                                'id': f'{image_id}/info.json',
+                                'id': f'{image_id}',
                                 'type': 'Image',
                             },
                             'target': canvas_id,

--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -34,7 +34,7 @@ class IIIFRecordManifestBuilder:
         return f'resource/{self.resource_id}/record/{self.record_id}'
 
     @property
-    def label(self) -> Dict[str, list]:
+    def label(self) -> Dict[str, List[str]]:
         return wrap_language(self.record[self.resource['_title_field']])
 
     @property

--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -100,7 +100,6 @@ class IIIFRecordManifestBuilder:
                             'body': {
                                 'id': f'{image_id}/info.json',
                                 'type': 'Image',
-                                'format': 'image/jpeg',
                             },
                             'target': canvas_id,
                         },

--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -77,6 +77,8 @@ class IIIFRecordManifestBuilder:
         :return: the canvas definition
         """
         canvas_id = create_id_url(f'{self.manifest_id}/canvas/{image_number}')
+        annotation_page_id = f'{canvas_id}/0'
+        annotation_id = f'{annotation_page_id}/0'
 
         return {
             'id': canvas_id,
@@ -88,11 +90,11 @@ class IIIFRecordManifestBuilder:
             'label': wrap_language(image_id),
             'items': [
                 {
-                    # TODO: do we need an id here?
+                    'id': annotation_page_id,
                     'type': 'AnnotationPage',
                     'items': [
                         {
-                            # TODO: do we need an id here?
+                            'id': annotation_id,
                             'type': 'Annotation',
                             'motivation': 'painting',
                             'body': {

--- a/ckanext/iiif/lib/manifest.py
+++ b/ckanext/iiif/lib/manifest.py
@@ -1,6 +1,7 @@
 import re
 from ckan import model
 from ckan.common import config
+from ckan.lib.helpers import url_for_static_or_external
 from ckan.plugins import toolkit
 from typing import List, Dict
 
@@ -123,8 +124,9 @@ class IIIFRecordManifestBuilder:
             'items': [self.build_canvas(i, image) for i, image in enumerate(self.images)],
             'logo': [
                 {
-                    'id': f'{config.get("ckan.site_url")}/images/logo.png',
+                    'id': url_for_static_or_external(config.get('ckan.site_logo')),
                     'type': 'Image',
+                    # TODO: need get these from somewhere dynamic?
                     'format': 'image/png',
                     'width': 120,
                     'height': 56,

--- a/ckanext/iiif/lib/utils.py
+++ b/ckanext/iiif/lib/utils.py
@@ -6,11 +6,6 @@ def create_id_url(identifier):
     return toolkit.url_for('iiif.resource', identifier=identifier, _external=True)
 
 
-def create_image_server_url(identifier_name, identifier_type='vfactor'):
-    image_server_url = config.get('ckanext.iiif.image_server_url')
-    return f'{image_server_url}/{identifier_type}:{identifier_name}'
-
-
 def wrap_language(value, language='en'):
     if not isinstance(value, list):
         value = [value]

--- a/ckanext/iiif/lib/utils.py
+++ b/ckanext/iiif/lib/utils.py
@@ -1,12 +1,25 @@
 from ckan.plugins import toolkit
-from typing import Dict
+from typing import Dict, List, Union
 
 
-def create_id_url(identifier) -> str:
+def create_id_url(identifier: str) -> str:
+    """
+    Given the identifier of a IIIF resource, creates the full URL for it.
+
+    :param identifier: the IIIF resource ID
+    :return: the full URL for the IIIF resource (e.g. a manifest)
+    """
     return toolkit.url_for('iiif.resource', identifier=identifier, _external=True)
 
 
-def wrap_language(value, language='en') -> Dict[str, list]:
+def wrap_language(value: Union[str, List[str]], language='en') -> Dict[str, List[str]]:
+    """
+    Wraps the given value in the appropriate structure required by IIIF to convey language options.
+
+    :param value: the value/values
+    :param language: the language, defaults to "en"
+    :return: the value in the right IIIF language format
+    """
     if not isinstance(value, list):
         value = [value]
     return {language: value}

--- a/ckanext/iiif/lib/utils.py
+++ b/ckanext/iiif/lib/utils.py
@@ -1,12 +1,12 @@
-from ckan.common import config
 from ckan.plugins import toolkit
+from typing import Dict
 
 
-def create_id_url(identifier):
+def create_id_url(identifier) -> str:
     return toolkit.url_for('iiif.resource', identifier=identifier, _external=True)
 
 
-def wrap_language(value, language='en'):
+def wrap_language(value, language='en') -> Dict[str, list]:
     if not isinstance(value, list):
         value = [value]
     return {language: value}

--- a/ckanext/iiif/plugin.py
+++ b/ckanext/iiif/plugin.py
@@ -45,15 +45,13 @@ class IIIFPlugin(plugins.SingletonPlugin):
     def datastore_multisearch_modify_response(self, response):
         resource_cache = {}
         resource_show = toolkit.get_action('resource_show')
-        vfactor_resource_id = toolkit.config.get('ckanext.nhm.vfactor_resource_id')
 
         for record in response['records']:
             resource_id = record['resource']
-            if resource_id == vfactor_resource_id:
-                if resource_id not in resource_cache:
-                    resource_cache[resource_id] = resource_show({}, {'id': resource_id})
-                with suppress(Exception):
-                    builder = IIIFRecordManifestBuilder(resource_cache[resource_id], record['data'])
-                    record['iiif'] = builder.build()
+            if resource_id not in resource_cache:
+                resource_cache[resource_id] = resource_show({}, {'id': resource_id})
+            with suppress(Exception):
+                builder = IIIFRecordManifestBuilder(resource_cache[resource_id], record['data'])
+                record['iiif'] = builder.build()
 
         return response


### PR DESCRIPTION
Previously, the manifest record level builder was basically designed to work with one dataset we have on the [NHM Data Portal](https://data.nhm.ac.uk/) and nothing else. Now that is not the case!

This PR also tidies up some parts of the manifest generation so that the resulting manifest is more compliant with the various viewers.