### PR TITLE
fix: allow the images in a manifest to be correctly opened in mirador etc

### DIFF
--- a/ckanext/iiif/builders/manifest.py
+++ b/ckanext/iiif/builders/manifest.py
@@ -211,6 +211,17 @@ class RecordManifestBuilder(IIIFResourceBuilder):
                             'body': {
                                 'id': image_id,
                                 'type': 'Image',
+                                # TODO: this is assuming the image is being served by a
+                                #       IIIF service and it's level2, which is will work
+                                #       for the key scenario we're supporting but
+                                #       nothing else
+                                'service': [
+                                    {
+                                        'id': image_id,
+                                        'type': 'ImageService3',
+                                        'profile': 'level2',
+                                    },
+                                ],
                             },
                             'target': canvas_id,
                         },

--- a/tests/unit/builders/test_manifest.py
+++ b/tests/unit/builders/test_manifest.py
@@ -151,7 +151,17 @@ class TestBuildCanvas:
         annotation = canvas['items'][0]['items'][0]
         assert annotation['type'] == 'Annotation'
         assert annotation['motivation'] == 'painting'
-        assert annotation['body'] == {'id': image_id, 'type': 'Image'}
+        assert annotation['body'] == {
+            'id': image_id,
+            'type': 'Image',
+            'service': [
+                {
+                    'id': image_id,
+                    'type': 'ImageService3',
+                    'profile': 'level2',
+                },
+            ],
+        }
 
 
 class TestGetImages:


### PR DESCRIPTION
Without this service section, Mirador (and others) has no idea that the image is a IIIF image and therefore just loads the static image. This change fixes that problem, but will break any non-IIIF image as a consequence. Fortunately, we're only using this functionality for IIIF specimen images so this large oversight isn't a problem right now. We will need to fix this later by finding a way to conditionally include or exclude this service section depending on whether the image is a IIIF image or not.

Fixes https://github.com/NaturalHistoryMuseum/ckanext-iiif/issues/13