### PR TITLE
Redirect canvas links to main iiif manifest

### DIFF
--- a/ckanext/iiif/builders/manifest.py
+++ b/ckanext/iiif/builders/manifest.py
@@ -38,7 +38,9 @@ class RecordManifestBuilder(IIIFResourceBuilder):
                  required format
         :raise: IIIFBuildError if anything goes wrong after the identifier is matched
         """
-        regex = re.compile('resource/(?P<resource_id>.+?)/record/(?P<record_id>.+)$')
+        regex = re.compile(
+            'resource/(?P<resource_id>.+?)/record/(?P<record_id>[^/]+).*$'
+        )
         match = regex.match(identifier)
         if not match:
             return None


### PR DESCRIPTION
Unclear if this is the correct way to do this; IIIF examples do not have canvas links that resolve and we can't find examples of separate/dereferenced canvas manifests. It may be that they're not expected to resolve (and most people probably won't be clicking on them anyway).

This will just prevent the logs filling up with errors if a bot decides to crawl us.

Fixes #33